### PR TITLE
Fix base path for Vercel deployment

### DIFF
--- a/apps/website/frontend/vite.config.ts
+++ b/apps/website/frontend/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  base: process.env.NODE_ENV === 'production' ? "/scibowl-org/" : "/",
+  base: "/",
   plugins: [react()],
 });


### PR DESCRIPTION
- Remove /scibowl-org/ base path
- Use root / for Vercel hosting
- Fixes asset loading issues (404s and MIME type errors)