### PR TITLE
Remove basename from BrowserRouter for Vercel

### DIFF
--- a/apps/website/frontend/src/App.tsx
+++ b/apps/website/frontend/src/App.tsx
@@ -114,7 +114,7 @@ function AppContent() {
 
 function App() {
   return (
-    <BrowserRouter basename={import.meta.env.PROD ? "/scibowl-org" : ""}>
+    <BrowserRouter>
       <AppContent />
     </BrowserRouter>
   );


### PR DESCRIPTION
- Remove /scibowl-org basename from React Router
- Router now matches root / path correctly
- Fixes blank page issue on Vercel