### PR TITLE
Add David Jiang to Thomas Jefferson roster (DASONI 2)

### DIFF
--- a/stats/dasoni-2/field.json
+++ b/stats/dasoni-2/field.json
@@ -144,7 +144,7 @@
     },
     {
       "name": "Thomas Jefferson",
-      "players": ["Sophia G", "Hrishi B", "Eshaan S", "Rohan B", "Nathan L", "Justin Y"]
+      "players": ["Sophia G", "Hrishi B", "Eshaan S", "Rohan B", "Nathan L", "Justin Y", "David Jiang"]
     },
     {
       "name": "North Allegheny",


### PR DESCRIPTION
## Summary
- Adds David Jiang to the Thomas Jefferson team roster in `stats/dasoni-2/field.json`
- David joins as the 7th player (bench slot)

## Change
`stats/dasoni-2/field.json` — Thomas Jefferson players array:
- Before: `["Sophia G", "Hrishi B", "Eshaan S", "Rohan B", "Nathan L", "Justin Y"]`
- After: `["Sophia G", "Hrishi B", "Eshaan S", "Rohan B", "Nathan L", "Justin Y", "David Jiang"]`