### PR TITLE
Add 'Submit a packet' form on scibowl.live

### DIFF
--- a/apps/website/frontend/src/App.tsx
+++ b/apps/website/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { useEffect } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { TournamentDetailPage, TournamentsLandingPage, TournamentsPage } from "./features/tournaments";
 import { isFeatureEnabled } from "./core/features";
-import { PacketSetDetailPage, PacketsPage } from "./features/packets";
+import { PacketSetDetailPage, PacketsPage, PacketSubmitPage } from "./features/packets";
 
 function TopNav() {
   const tournamentsEnabled = isFeatureEnabled("tournaments");
@@ -134,6 +134,7 @@ function AppContent() {
               {packetsEnabled && (
                 <>
                   <Route path="/packets" element={<PacketsPage />} />
+                  <Route path="/packets/submit" element={<PacketSubmitPage />} />
                   <Route path="/packets/:slug" element={<PacketSetDetailPage />} />
                 </>
               )}

--- a/apps/website/frontend/src/features/packets/index.ts
+++ b/apps/website/frontend/src/features/packets/index.ts
@@ -1,3 +1,4 @@
 export { PacketsPage } from "./pages/PacketsPage";
 export { PacketSetDetailPage } from "./pages/PacketSetDetailPage";
+export { PacketSubmitPage } from "./pages/PacketSubmitPage";
 

--- a/apps/website/frontend/src/features/packets/pages/PacketSubmitPage.tsx
+++ b/apps/website/frontend/src/features/packets/pages/PacketSubmitPage.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { Link } from "react-router-dom";
+
+// LeBot's /upload endpoint validates, saves to the VPS, and pings Sage. CORS is open there.
+const UPLOAD_URL = import.meta.env.VITE_UPLOAD_URL ?? "https://lebot.djiang.xyz/upload";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string };
+
+export function PacketSubmitPage() {
+  const [tournament, setTournament] = useState("");
+  const [submitter, setSubmitter] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const canSubmit = tournament.trim().length > 0 && file !== null && status.kind !== "submitting";
+
+  const submit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!tournament.trim() || !file) return;
+    setStatus({ kind: "submitting" });
+
+    const body = new FormData();
+    body.append("tournament", tournament.trim());
+    body.append("submitter", submitter.trim());
+    body.append("file", file);
+
+    try {
+      const res = await fetch(UPLOAD_URL, { method: "POST", body });
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; message?: string; error?: string };
+      if (res.ok && data.ok) {
+        setStatus({ kind: "success", message: data.message ?? "Uploaded — thanks!" });
+        setTournament("");
+        setSubmitter("");
+        setFile(null);
+        event.currentTarget.reset();
+      } else {
+        setStatus({ kind: "error", message: data.error ?? "Upload failed. Please try again." });
+      }
+    } catch {
+      setStatus({ kind: "error", message: "Could not reach the server. Please try again." });
+    }
+  };
+
+  return (
+    <div className="sbStack">
+      <div className="card sbTournamentCard sbHeroCard">
+        <Link to="/packets" className="sbInlineLink">
+          <ArrowLeftIcon className="sbIcon" aria-hidden="true" /> Back to packets
+        </Link>
+        <h1 className="sbHeroTitle sbHeroTitleTight">Submit a packet</h1>
+        <p className="sbMuted sbTopSpace">
+          Share an invitational set with the community. PDF or DOCX, up to 30&nbsp;MB. Submissions are
+          reviewed before they appear.
+        </p>
+      </div>
+
+      <form className="card" onSubmit={submit}>
+        <label className="sbField">
+          <span className="sbFieldLabel">Tournament name *</span>
+          <input
+            className="sbInput"
+            value={tournament}
+            onChange={(e) => setTournament(e.target.value)}
+            placeholder="e.g. AVES 2025"
+            required
+          />
+        </label>
+
+        <label className="sbField sbTopSpace">
+          <span className="sbFieldLabel">Your name (optional)</span>
+          <input
+            className="sbInput"
+            value={submitter}
+            onChange={(e) => setSubmitter(e.target.value)}
+            placeholder="so we can credit you"
+          />
+        </label>
+
+        <label className="sbField sbTopSpace">
+          <span className="sbFieldLabel">Packet file *</span>
+          <input
+            className="sbInput"
+            type="file"
+            accept=".pdf,.docx"
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            required
+          />
+        </label>
+
+        <button type="submit" className="sbPageButton sbTopSpace" disabled={!canSubmit}>
+          {status.kind === "submitting" ? "Uploading…" : "Upload packet"}
+        </button>
+
+        {status.kind === "success" && (
+          <p className="sbMuted sbTopSpace" role="status">
+            ✓ {status.message}
+          </p>
+        )}
+        {status.kind === "error" && (
+          <p className="sbTopSpace sbError" role="alert">
+            {status.message}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/apps/website/frontend/src/features/packets/pages/PacketsPage.tsx
+++ b/apps/website/frontend/src/features/packets/pages/PacketsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { PacketSetRow } from "../components/PacketSetRow";
 import { usePacketSets } from "../hooks/usePacketSets";
 
@@ -34,6 +34,9 @@ export function PacketsPage() {
       <div className="card sbTournamentCard sbHeroCard">
         <h1 className="sbTitle">Question Packets</h1>
         <p className="sbMuted sbTopSpace">Search and filter invitational question sets.</p>
+        <Link to="/packets/submit" className="sbPageButton sbTopSpace">
+          Submit a packet
+        </Link>
 
         <div className="sbListingControls sbTopSpace">
           <label className="sbField">


### PR DESCRIPTION
Puts the packet-upload form **on the site** (not on LeBot).

- New page **`/packets/submit`** (`PacketSubmitPage.tsx`): tournament name (required), your name (optional), file input restricted to `.pdf,.docx`. On submit it POSTs multipart to LeBot's `/upload` JSON API and shows inline success/error.
- Exposed via a **"Submit a packet"** button on the Packets page.
- Endpoint is configurable via `VITE_UPLOAD_URL` (defaults to `https://lebot.djiang.xyz/upload`).

Backend (validation, VPS save, Sage ping, rate limit) is the companion LeBot PR #5 — merge & deploy that for uploads to actually land. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)